### PR TITLE
Add an option - outer_join_hierarchical - to include non-hierarchical entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,13 @@ FROM "categories" INNER JOIN (
 ORDER BY "categories__recursive"."__order_column" ASC
 ```
 
+If you want to use a ```LEFT OUTER JOIN``` instead, add a query option for ```outer_join_hierarchical```
+```ruby
+.join_recursive(outer_join_hierarchical: true)
+```
+
+This option allows the query to return non-hierarchical entries.
+
 ## Related resources
 
 * [About hierarchical queries (Wikipedia)](http://en.wikipedia.org/wiki/Hierarchical_and_recursive_queries_in_SQL)


### PR DESCRIPTION
@keithmgould @nickfarina @raycchan
Adding a query option
``` outer_join_hierarchical ```
 
This option includes non-hierarchical entries if specified

For example, the query outer self joins CTE table (for example: container__recursive) with the STI table (for example: containers), and returns a single table that contains both hierarchical entries (containers with containers) and non-hierarchical entries (containers without any containers inside)

The resulting query will be
```
SELECT containers.*
FROM containers
LEFT OUTER JOIN (WITH RECURSIVE containers__recursive AS
              (SELECT <..columns..>
               FROM containers
               <...additional joined tables in CTE..>
               WHERE containers.retired_at IS NULL
               UNION ALL SELECT <..columns..>
               FROM containers
               <...additional joined tables in CTE..>
               INNER JOIN containers__recursive ON containers__recursive.parent_id = containers.id
               WHERE containers.retired_at IS NULL)
            SELECT containers__recursive.*
            FROM containers__recursive) AS containers__recursive ON containers.id = containers__recursive.parent_id
WHERE containers.retired_at IS NULL
```

instead of
SELECT containers.*
FROM containers
**INNER JOIN** (WITH RECURSIVE containers__recursive AS
...
