### PR TITLE
Introducing a new distinct method on the query instead of using an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ By default, the union term in the Common Table Expression uses a `UNION ALL`. If
 to `SELECT DISTINCT` CTE values, add a query option for  `distinct`
 ```ruby
 Category.join_recursive do |query|
-query.connect_by(id: :parent_id)
-     .start_with(id: node_1.id)
-     .distinct
+  query.connect_by(id: :parent_id)
+       .start_with(id: node_1.id)
+       .distinct
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ Category.join_recursive do |query|
 end
 ```
 
+## DISTINCT
+By default, the union term in the Common Table Expression uses a `UNION ALL`. If you want
+to `SELECT DISTINCT` CTE values, add a query option for  `distinct`
+```ruby
+Category.join_recursive do |query|
+query.connect_by(id: :parent_id)
+     .start_with(id: node_1.id)
+     .distinct
+end
+```
+
 ## Generated SQL queries
 
 Under the hood this extensions builds `INNER JOIN` to recursive subquery.
@@ -298,11 +309,6 @@ ORDER BY "categories__recursive"."__order_column" ASC
 If you want to use a `LEFT OUTER JOIN` instead of an `INNER JOIN`, add a query option for `outer_join_hierarchical`.   This option allows the query to return non-hierarchical entries:
 ```ruby
   .join_recursive(outer_join_hierarchical: true)
-```
-
-If you want to `SELECT DISTINCT` values, add a query option for  `distinct`
-```ruby
-  .join_recursive(distinct: true)
 ```
 
 If, when joining the recursive view to the main table, you want to change the foreign_key on the recursive view from the primary key of the main table to another column:

--- a/lib/active_record/hierarchical_query/cte/query_builder.rb
+++ b/lib/active_record/hierarchical_query/cte/query_builder.rb
@@ -11,17 +11,15 @@ module ActiveRecord
       class QueryBuilder
         attr_reader :query,
                     :columns,
-                    :cycle_detector,
-                    :options
+                    :cycle_detector
 
         delegate :klass, :table, :recursive_table, to: :query
 
         # @param [ActiveRecord::HierarchicalQuery::Query] query
-        def initialize(query, options = {})
+        def initialize(query)
           @query = query
           @columns = Columns.new(@query)
           @cycle_detector = CycleDetector.new(@query)
-          @options = options
         end
 
         def bind_values
@@ -60,7 +58,7 @@ module ActiveRecord
         end
 
         def build_select
-          if @options[:distinct] == true
+          if @query.distinct_value == true
             @arel.project(recursive_table[Arel.star]).distinct
           else
             @arel.project(recursive_table[Arel.star])

--- a/lib/active_record/hierarchical_query/join_builder.rb
+++ b/lib/active_record/hierarchical_query/join_builder.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       # @param [#to_s] subquery_alias
       def initialize(query, join_to, subquery_alias, options = {})
         @query = query
-        @builder = CTE::QueryBuilder.new(query, options)
+        @builder = CTE::QueryBuilder.new(query)
         @relation = join_to
         @alias = Arel::Table.new(subquery_alias, ActiveRecord::Base)
         @options = options
@@ -19,6 +19,7 @@ module ActiveRecord
         # default option when flag is not specified is to include only entries participating
         # in a hierarchy
         join_sql = @options[:outer_join_hierarchical] == true ? outer_join.to_sql : inner_join.to_sql
+
         relation = @relation.joins(join_sql)
 
         # copy bound variables from inner subquery (remove duplicates)

--- a/lib/active_record/hierarchical_query/query.rb
+++ b/lib/active_record/hierarchical_query/query.rb
@@ -20,7 +20,8 @@ module ActiveRecord
                   :limit_value,
                   :offset_value,
                   :order_values,
-                  :nocycle_value
+                  :nocycle_value,
+                  :distinct_value
 
       # @api private
       CHILD_SCOPE_METHODS = :where, :joins, :group, :having, :bind
@@ -36,6 +37,7 @@ module ActiveRecord
         @offset_value = nil
         @nocycle_value = false
         @order_values = []
+        @distinct_value = false
       end
 
       # Specify root scope of the hierarchy.
@@ -268,6 +270,15 @@ module ActiveRecord
       #   end
       def table
         @klass.arel_table
+      end
+
+      # Turn on/off select distinct option in the CTE.
+      #
+      # @param [true, false] value
+      # @return [ActiveRecord::HierarchicalQuery::Query] self
+      def distinct(value = true)
+        @distinct_value = value
+        self
       end
 
       # @return [Arel::Nodes::Node]

--- a/lib/active_record/hierarchical_query/query.rb
+++ b/lib/active_record/hierarchical_query/query.rb
@@ -272,12 +272,11 @@ module ActiveRecord
         @klass.arel_table
       end
 
-      # Turn on/off select distinct option in the CTE.
+      # Turn on select distinct option in the CTE.
       #
-      # @param [true, false] value
       # @return [ActiveRecord::HierarchicalQuery::Query] self
-      def distinct(value = true)
-        @distinct_value = value
+      def distinct
+        @distinct_value = true
         self
       end
 

--- a/spec/active_record/hierarchical_query_spec.rb
+++ b/spec/active_record/hierarchical_query_spec.rb
@@ -260,10 +260,9 @@ describe ActiveRecord::HierarchicalQuery do
     end
   end
 
-  describe ':distinct query option' do
-    subject { klass.join_recursive(distinct: value) { connect_by(id: :parent_id) }.to_sql }
+  describe ':distinct query method' do
+    subject { klass.join_recursive { connect_by(id: :parent_id).distinct }.to_sql }
 
-    let(:value) { true }
     let(:select) {
       /SELECT \"categories__recursive\"/
     }
@@ -272,23 +271,7 @@ describe ActiveRecord::HierarchicalQuery do
       expect(subject).to match /SELECT DISTINCT \"categories__recursive\"/
     end
 
-    context 'value is false' do
-      let(:value) { false }
-
-      it 'selects without using a distinct' do
-        expect(subject).to match select
-      end
-    end
-
-    context 'value is a string' do
-      let(:value) { 'foo' }
-
-      it 'selects without using a distinct' do
-        expect(subject).to match select
-      end
-    end
-
-    context 'key is absent' do
+    context 'distinct method is absent' do
       subject { klass.join_recursive { connect_by(id: :parent_id) }.to_sql }
 
       it 'selects without using a distinct' do


### PR DESCRIPTION
Trying to merge distinct option back to open source version: https://github.com/take-five/activerecord-hierarchical_query/pull/9, the author suggested that I
> considered introducing new method distinct instead of introducing an option? I.e.:

```sql
Category.join_recursive do |query|
  query.connect_by(id: :parent_id)
       .start_with(id: node_1.id)
       .distinct
end
```

@keithmgould @nickfarina @raycchan @TheDudeWithTheThing could you please review?